### PR TITLE
feat(trackers): add Samaritano support

### DIFF
--- a/defs/trackers/samaritano.json
+++ b/defs/trackers/samaritano.json
@@ -26,7 +26,6 @@
       "value": "profile-mini-stat__value"
     },
     "labels": {
-      "ratio": "real_ratio",
       "tempo total de seed": "total_seedtime",
       "tempo médio de seed": "avg_seed_time",
       "top seedsize": "seed_size",
@@ -35,7 +34,7 @@
       "total em seed": "seeding",
       "total em leech": "leeching",
       "convites": "invites",
-      "token freeleech": "fl_tokens",
+      "meus tokens fl": "fl_tokens",
       "data de registro": "join_date"
     }
   },

--- a/defs/trackers/samaritano.json
+++ b/defs/trackers/samaritano.json
@@ -1,0 +1,345 @@
+{
+  "schema_version": 1,
+  "key": "samaritano",
+  "name": "Samaritano",
+  "abbr": "SAM",
+  "url": "https://samaritano.cc",
+  "type": "unit3d",
+  "last_updated": "2026-07-29",
+  "rules": {
+    "min_ratio": 0.4,
+    "min_seed_days": 3,
+    "note": "Ratio below 1.00 with a negative buffer demotes the account to Leech."
+  },
+  "scrape": {
+    "stat_card_classes": {
+      "label": "profile-mini-stat__label",
+      "value": "profile-mini-stat__value"
+    },
+    "labels": {
+      "ratio": "real_ratio",
+      "tempo total de seed": "total_seedtime",
+      "tempo médio de seed": "avg_seed_time",
+      "top seedsize": "seed_size",
+      "uploads": "uploads",
+      "snatches dos seus uploads": "upload_snatches",
+      "total em seed": "seeding",
+      "total em leech": "leeching",
+      "convites": "invites",
+      "token freeleech": "fl_tokens",
+      "data de registro": "join_date"
+    }
+  },
+  "groups": [
+    {
+      "name": "Leech",
+      "style": { "color": "#800000", "icon": "fas fa-mosquito" },
+      "requirements": { "description": "Automatic demotion group for accounts with ratio below 1.00 and a negative buffer." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 0" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" }
+      ]
+    },
+    {
+      "name": "User",
+      "style": { "color": "#7289DA", "icon": "fas fa-user" },
+      "requirements": {
+        "min_ratio": 0.4
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 3" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" }
+      ]
+    },
+    {
+      "name": "Habitante",
+      "style": { "color": "#2980b9", "icon": "fas fa-house-user" },
+      "requirements": {
+        "min_uploaded": "1 TiB",
+        "min_ratio": 1.0,
+        "min_age": "1M",
+        "min_seedtime": "1W",
+        "min_seed_size": "1.5 GiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 15" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" }
+      ]
+    },
+    {
+      "name": "Benfeitor",
+      "style": { "color": "#27ae60", "icon": "fas fa-hand-holding-heart" },
+      "requirements": {
+        "min_uploaded": "5 TiB",
+        "min_ratio": 1.0,
+        "min_age": "4M",
+        "min_seedtime": "1W",
+        "min_seed_size": "1.5 GiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 25" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" }
+      ]
+    },
+    {
+      "name": "Protetor",
+      "style": { "color": "#34495e", "icon": "fas fa-shield-heart" },
+      "requirements": {
+        "min_uploaded": "10 TiB",
+        "min_ratio": 1.5,
+        "min_age": "5M",
+        "min_seedtime": "1M",
+        "min_seed_size": "1.5 GiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 25" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" }
+      ]
+    },
+    {
+      "name": "Sentinela",
+      "style": { "color": "#8e44ad", "icon": "fas fa-tower-observation" },
+      "requirements": {
+        "min_uploaded": "25 TiB",
+        "min_ratio": 1.0,
+        "min_age": "6M",
+        "min_seedtime": "1M",
+        "min_seed_size": "1.5 GiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 30" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" }
+      ]
+    },
+    {
+      "name": "Bom-Samaritano",
+      "style": { "color": "#f1c40f", "icon": "fas fa-handshake-angle" },
+      "requirements": {
+        "min_uploaded": "50 TiB",
+        "min_ratio": 1.0,
+        "min_age": "1Y",
+        "min_seedtime": "1M",
+        "min_seed_size": "1.5 GiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 60" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" }
+      ]
+    },
+    {
+      "name": "Guardião",
+      "style": { "color": "#f39c12", "icon": "fas fa-helmet-battle" },
+      "requirements": {
+        "min_uploaded": "75 TiB",
+        "min_ratio": 1.0,
+        "min_age": "12M",
+        "min_seedtime": "1M 2W 1D",
+        "min_seed_size": "1.5 GiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 80" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-chevron-double-up torrent-icons__double-upload", "label": "Upload duplo" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" }
+      ]
+    },
+    {
+      "name": "Veterano",
+      "style": { "color": "#d35400", "icon": "fas fa-medal fa-fade", "sparkle": true },
+      "requirements": {
+        "min_uploaded": "100 TiB",
+        "min_ratio": 1.0,
+        "min_age": "1Y",
+        "min_seedtime": "1M 2W 1D"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-chevron-double-up torrent-icons__double-upload", "label": "Upload duplo" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Colaborador Junior",
+      "style": { "color": "#1abc9c", "icon": "fas fa-seedling" },
+      "requirements": {
+        "min_uploaded": "5 TiB",
+        "min_ratio": 1.0,
+        "min_age": "1M",
+        "min_seedtime": "1W",
+        "min_seed_size": "1.5 GiB",
+        "min_uploads": 50
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 40" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" }
+      ]
+    },
+    {
+      "name": "Colaborador Pleno",
+      "style": { "color": "#16a085", "icon": "fas fa-leaf" },
+      "requirements": {
+        "min_uploaded": "10 TiB",
+        "min_ratio": 1.0,
+        "min_age": "6M",
+        "min_seedtime": "1W",
+        "min_seed_size": "1.5 GiB",
+        "min_uploads": 150
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 50" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-chevron-double-up torrent-icons__double-upload", "label": "Upload duplo" }
+      ]
+    },
+    {
+      "name": "Colaborador Senior",
+      "style": { "color": "#117a65", "icon": "fas fa-tree" },
+      "requirements": {
+        "min_uploaded": "25 TiB",
+        "min_ratio": 1.0,
+        "min_age": "12M",
+        "min_seedtime": "1M 2W 1D",
+        "min_seed_size": "1.5 GiB",
+        "min_uploads": 300
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 60" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-chevron-double-up torrent-icons__double-upload", "label": "Upload duplo" }
+      ]
+    },
+    {
+      "name": "Cultivador",
+      "style": { "color": "#2ecc71", "icon": "fas fa-wheat-awn", "sparkle": true },
+      "requirements": {
+        "min_uploaded": "200 TiB",
+        "min_ratio": 1.0,
+        "min_age": "1M",
+        "min_seedtime": "1M",
+        "min_seed_size": "5 TiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-chevron-double-up torrent-icons__double-upload", "label": "Upload duplo" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Arquivista",
+      "style": { "color": "#16a085", "icon": "fas fa-box-archive", "sparkle": true },
+      "requirements": {
+        "min_ratio": 1.0,
+        "min_age": "1M",
+        "min_seedtime": "1M",
+        "min_seed_size": "30 TiB"
+      },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-chevron-double-up torrent-icons__double-upload", "label": "Upload duplo" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Internal",
+      "style": { "color": "#BAAF92", "icon": "fas fa-magic", "sparkle": true },
+      "requirements": { "description": "Member of a Samaritano internal release group." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Uploader",
+      "style": { "color": "#00ff2d", "icon": "fas fa-upload", "sparkle": true },
+      "requirements": { "description": "Discretionary group for trusted uploaders." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Torrent Moderator",
+      "style": { "color": "#2980b9", "icon": "fas fa-badge-check" },
+      "requirements": { "description": "Staff group that checks pending torrents in the moderation queue." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Bot",
+      "style": { "color": "#d44b00", "icon": "fas fa-user-robot" },
+      "requirements": { "description": "Site bot accounts." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Editor",
+      "style": { "color": "#15B097", "icon": "fas fa-user-pen" },
+      "requirements": { "description": "Discretionary group that fixes other users' torrent pages." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    },
+    {
+      "name": "Trustee",
+      "style": { "color": "#272727", "icon": "fas fa-shield" },
+      "requirements": { "description": "Discretionary group for close associates of the site." },
+      "perks": [
+        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
+        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
+        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
+        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
+        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
+        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
+      ]
+    }
+  ]
+}

--- a/defs/trackers/samaritano.json
+++ b/defs/trackers/samaritano.json
@@ -42,7 +42,7 @@
     {
       "name": "Leech",
       "style": { "color": "#800000", "icon": "fas fa-mosquito" },
-      "requirements": { "description": "Automatic demotion group for accounts with ratio below 1.00 and a negative buffer." },
+      "requirements": { "description": "Starting group for new registrations. Accounts that fall below ratio 1.00 with a negative buffer are also placed here." },
       "perks": [
         { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: 0" },
         { "icon": "fas fa-upload text-success", "label": "Upload Torrents" }
@@ -273,19 +273,6 @@
       ]
     },
     {
-      "name": "Internal",
-      "style": { "color": "#BAAF92", "icon": "fas fa-magic", "sparkle": true },
-      "requirements": { "description": "Member of a Samaritano internal release group." },
-      "perks": [
-        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
-        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
-        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
-        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
-        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
-        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
-      ]
-    },
-    {
       "name": "Uploader",
       "style": { "color": "#00ff2d", "icon": "fas fa-upload", "sparkle": true },
       "requirements": { "description": "Discretionary group for trusted uploaders." },
@@ -302,19 +289,6 @@
       "name": "Torrent Moderator",
       "style": { "color": "#2980b9", "icon": "fas fa-badge-check" },
       "requirements": { "description": "Staff group that checks pending torrents in the moderation queue." },
-      "perks": [
-        { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
-        { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },
-        { "icon": "fas fa-paper-plane", "label": "Enviar convite" },
-        { "icon": "fas fa-star text-gold", "label": "Freeleech" },
-        { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
-        { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
-      ]
-    },
-    {
-      "name": "Bot",
-      "style": { "color": "#d44b00", "icon": "fas fa-user-robot" },
-      "requirements": { "description": "Site bot accounts." },
       "perks": [
         { "icon": "fas fa-arrow-down-short-wide text-blue", "label": "DL slots: ∞" },
         { "icon": "fas fa-upload text-success", "label": "Upload Torrents" },

--- a/defs/trackers/samaritano.json
+++ b/defs/trackers/samaritano.json
@@ -5,13 +5,22 @@
   "abbr": "SAM",
   "url": "https://samaritano.cc",
   "type": "unit3d",
-  "last_updated": "2026-07-29",
+  "last_updated": "2026-07-30",
+  "approved_by": {
+    "name": "ØVERLORD",
+    "role": "Owner/Admin",
+    "date": "2026-07-30"
+  },
   "rules": {
     "min_ratio": 0.4,
     "min_seed_days": 3,
     "note": "Ratio below 1.00 with a negative buffer demotes the account to Leech."
   },
   "scrape": {
+    "disable_scraping": false,
+    "min_interval_minutes": 180,
+    "max_scrapes_per_day": 8,
+    "identify": "ua",
     "stat_card_classes": {
       "label": "profile-mini-stat__label",
       "value": "profile-mini-stat__value"
@@ -340,6 +349,21 @@
         { "icon": "fas fa-syringe", "label": "Immune to automated HnR warnings" },
         { "icon": "fas fa-tasks", "label": "Moderação de Torrent bypass" }
       ]
+    },
+    {
+      "name": "Moderador",
+      "style": { "color": "#4ECDC4", "icon": "fas fa-user-shield" },
+      "requirements": { "description": "Samaritano moderator." }
+    },
+    {
+      "name": "Administrator",
+      "style": { "color": "#f92672", "icon": "fas fa-user-secret" },
+      "requirements": { "description": "Samaritano administrator." }
+    },
+    {
+      "name": "Owner",
+      "style": { "color": "#c3f32f", "icon": "fas fa-crown" },
+      "requirements": { "description": "Samaritano owner." }
     }
   ]
 }


### PR DESCRIPTION
## Status

Adds a tracker definition for Samaritano (SAM), a Brazilian UNIT3D tracker (UNIT3D v9.2.0 + UNIT3D-Announce). Same approach as CapybaraBR in #21: the standard `unit3d` type handles the API, with pt-BR label overrides for scraping. The site runs a customized profile layout, so the definition also sets `stat_card_classes` to the site's own stat card markup.

- [x] Samaritano (SAM)

## Staff approval

The site owner went through the project before answering and approved scraping of the user's own profile page. He set the limits himself, and they are all in the def now:

- Minimum interval: 180 minutes (`min_interval_minutes`)
- Daily cap: 8 reads (`max_scrapes_per_day`)
- Identification: `Yata/<version>` in the User-Agent (`identify: "ua"`), which he preferred over the separate header so it greps out of their access logs
- Recorded in `approved_by`: OVERLORD, Owner/Admin, 2026-07-30

He also passed along three staff groups that are not listed on the public class page (Moderador, Administrator, Owner), included here with the colors and icons he gave.

## Details

- Full class list from the class requirements page, verified 2026-07-29, with the site's colors, icons, requirements and perks. This includes the upload-count track (Colaborador Junior/Pleno/Senior) and the seeding classes (Cultivador, Arquivista).
- Site rules: minimum ratio 0.4, 72 hour hit and run window, and accounts below ratio 1.00 with a negative buffer get demoted to Leech.
- No invite requirements block since the base User class can already send invites.
- Tested against a live account on a local build, both the API and the profile scrape, with the extracted fields checked one by one against the rendered page.

## Notes

Two things turned up while checking the scraped fields against the live page. Neither is specific to this def, so I left the def honest rather than working around them:

- The page uses the plain label "Ratio" twice with different meanings: the credited ratio in the top bar and the real ratio in the traffic section. The generic label pass fills the field before `stat_card_classes` gets a chance to disambiguate by CSS class, so `real_ratio` is left unset here instead of carrying the wrong number.
- `parse.SeedTimeToSeconds` tells months from minutes by letter case (`M` against `m`) and does not know the Portuguese unit letters, so this site's `2m 4d 13h 59m 13s` (2 months) parses as 2 minutes and the `178a` years are dropped entirely. CapybaraBR's total seed time in #21 loses its years the same way. I have the evidence written up and can send a separate PR for the parser if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the Samaritano tracker configuration by adjusting the **Leech** group requirement wording while keeping the same ratio-below-1.00 logic.
  - Removed the **Internal** and **Bot** role tiers from the Samaritano tracker, so those tiers are no longer available in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->