### PR TITLE
HHD added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ All notable changes to Yata, newest first. Versions are date-based builds:
 
 ## [Unreleased]
 
+## [Beta-20260830]
+
+### Added
+
+- **HHD (homiehelpdesk.net) is supported**, API-only. Its `/api/user` covers
+  every stat its ten-rung ladder is measured against — seed size, average seed
+  time, upload counts and the rest — so nothing is scraped and the def declares
+  no scrape at all.
+
+  It is also the first UNIT3D tracker to report a **join date** from the API.
+  Stock UNIT3D doesn't, which is why other UNIT3D defs ask you to type one at
+  setup; HHD's is read automatically. That exposed a latent bug worth naming:
+  the join date arrived as a full timestamp, and the pathway engine parses
+  dates strictly, so an established account would have read as brand new and
+  quietly failed every account-age requirement in its ladder. Timestamps are
+  now normalised for every fetcher rather than only the custom ones.
+
+  Its API also reports a **last login time**, which Yata now records. Nothing
+  displays it yet — it is there so history accumulates before the login-recency
+  warnings that need it.
+
+### Changed
+
+- **Group and class alert conditions are now one field with three options.**
+  Building "tell me when I'm promoted" meant knowing that *Group / class →
+  changed* and the separate *Promoted* and *Demoted* fields were three
+  different things. They are now one **Group / class** condition offering
+  **changed**, **promotions** and **demotions**.
+
+  This also closes a trap. "changed" is checked on every refresh while
+  promotions and demotions fire once at the moment they happen, so a rule
+  selecting both sent two notifications for the same promotion; one condition
+  row can now only pick one of them. Existing rules are untouched — the stored
+  form hasn't changed, so nothing needs migrating and rules written before this
+  simply display the new way.
+
+- **Pathway data refreshed** to the August 2026 community dataset (591 routes).
+
+### Fixed
+
+- **LST stopped reporting any stats after they changed their API.** The stats
+  moved inside a `data` wrapper, and every field Yata looks for is read from
+  the top level — so the request succeeded, the response parsed, and the
+  tracker reported *nothing*, with no error anywhere to notice. Wrapped
+  responses are now unwrapped for any UNIT3D tracker that adopts the same
+  shape, so this doesn't have to be fixed again one tracker at a time.
+
+  LST also began issuing **expiring API keys** and reports the expiry date
+  alongside the stats. Yata records it, ready for the warnings that come next.
+  The rest of that block — which describes the credential itself — is
+  deliberately discarded at the boundary, so nothing about a key can ever end
+  up in stored stats or their history.
+
+- **A pathway requirement was cut off mid-word.** The YuScene → MidnightScene
+  route read "6 months, 3TB uplo". The pathways file is generated from the
+  community dataset, so correcting the file alone would have been silently
+  undone by the next refresh; the correction now lives in the generator, keyed
+  to that one route so it cannot affect any other. When the upstream dataset is
+  fixed, the next refresh reports that the workaround is no longer needed
+  instead of leaving it in place forever.
+
 ## [Beta-20260804]
 
 ### Added

--- a/defs/templates/tracker.template.jsonc
+++ b/defs/templates/tracker.template.jsonc
@@ -71,7 +71,11 @@
   // Canonical names: username, group, uploaded, downloaded, ratio, real_ratio,
   //   buffer, bonus_points, seeding, leeching, hit_and_runs, fl_tokens,
   //   seed_size, avg_seed_time, total_seedtime, join_date, snatched,
-  //   upload_snatches, invites, warnings, uploads_approved, requests_filled.
+  //   upload_snatches, invites, warnings, uploads_approved, requests_filled,
+  //   last_login.
+  // uploads_approved is named for the scrape-era label; where a tracker's
+  // ladder counts plain uploads, map that counter here — it is the number
+  // the progression is actually measured against.
   "api_field_map": {
     "seedbonus": "bonus_points"
   },

--- a/defs/trackers/homiehelpdesk.json
+++ b/defs/trackers/homiehelpdesk.json
@@ -1,0 +1,695 @@
+{
+  "schema_version": 1,
+  "key": "homiehelpdesk",
+  "name": "HHD",
+  "abbr": "HHD",
+  "url": "https://homiehelpdesk.net",
+  "type": "unit3d",
+  "last_updated": "2026-08-30",
+  "api_field_map": {
+    "joined_at": "join_date",
+    "seedtime_total": "total_seedtime",
+    "uploads_count": "uploads_approved"
+  },
+  "capabilities": {
+    "api_stats_add": [
+      "avg_seed_time",
+      "fl_tokens",
+      "invites",
+      "last_login",
+      "real_downloaded",
+      "real_uploaded",
+      "seed_size",
+      "total_seedtime",
+      "uploads_approved"
+    ]
+  },
+  "scrape": {
+    "disable_scraping": true
+  },
+  "rules": {
+    "min_ratio": 0.4,
+    "min_seed_days": 7
+  },
+  "invite_requirements": {
+    "note": "Specialist or above for invite-forum access."
+  },
+  "notes": "API-only: /api/user covers every stat the class ladder needs, so nothing is scraped. Bearer auth only — ?api_token= returns 401. Unusually for UNIT3D it reports a join date (joined_at), so no api.required_fields entry is needed. uploads_count → uploads_approved is the tracker's OWN progression counter — the number its Min. Uploads rungs are measured against, confirmed by HHD staff usage; the canonical name is a leftover from when that stat could only be scraped, and carries no 'approved-only' meaning here. last_login is reported as a full ISO timestamp and is deliberately NOT trimmed to a date the way join_date is, so a future login-recency requirement (e.g. log in every 30 days) can still see the time of day; nothing consumes it yet. The API also returns *_raw twins of the formatted values (uploaded_raw, seed_size_raw, avg_seed_time_raw, …) which are deliberately unmapped: the formatted forms already parse, and avg_seed_time's string resolves to exactly avg_seed_time_raw. credited_uploaded, credited_downloaded, bonus_uploaded, downloads_count, is_donor and is_lifetime have no canonical equivalent and are left alone. Group colours are HHD's own hex values, taken from its Groups Requirements page. Its icons are Phosphor (ph-bold ph-battery-low, …), NOT FontAwesome, so they are translated to the nearest FontAwesome free equivalent rather than copied verbatim as other defs do: Yata ships FontAwesome, and an unresolvable class falls back to a generic star, which would have rendered all ten rungs identically. The battery progression HHD uses for User→Extreme survives the translation intact. Original Phosphor names, if the icon set is ever added: Leech=ph-prohibit, User=ph-battery-empty, Homies=ph-battery-low, Super User=ph-battery-medium, Specialist=ph-battery-high, Extreme=ph-battery-full, Seeder=ph-calculator, Insane User=ph-laptop, Veteran=ph-cube, Archivist=ph-robot. Groups run Leech → Bot in the tracker's own page order and include the staff and awarded ranks, so a user who holds one still sees their colour and icon; the pre-Leech states (Pruned, Banned, Disabled, Downtime, Validating) are omitted because the API stops answering for those accounts, so Yata could never observe them. Ranks with no measurable ladder requirement carry a description instead, per darkpeers. Jr Uploader and Uploader appear on HHD's page twice — once here and once on a separate Uploader Track with its own upload counts; those counts are recorded in the description rather than as min_uploads, because the track runs alongside the seeding ladder rather than continuing it. sparkle marks the ranks HHD renders with sparkels.gif behind the name.",
+  "groups": [
+    {
+      "name": "Leech",
+      "style": {
+        "color": "#581C0F",
+        "icon": "fas fa-ban"
+      },
+      "requirements": {},
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 0"
+        }
+      ]
+    },
+    {
+      "name": "User",
+      "style": {
+        "color": "#14532D",
+        "icon": "fas fa-battery-empty"
+      },
+      "requirements": {
+        "min_ratio": 0.4
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 10"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        }
+      ]
+    },
+    {
+      "name": "Homies",
+      "style": {
+        "color": "#15803D",
+        "icon": "fas fa-battery-quarter"
+      },
+      "requirements": {
+        "min_uploaded": "1 TiB",
+        "min_ratio": 0.5,
+        "min_age": "1M",
+        "min_seedtime": "1W"
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 15"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        }
+      ]
+    },
+    {
+      "name": "Super User",
+      "style": {
+        "color": "#22C55E",
+        "icon": "fas fa-battery-half"
+      },
+      "requirements": {
+        "min_uploaded": "2 TiB",
+        "min_ratio": 0.6,
+        "min_age": "1M",
+        "min_seedtime": "2W",
+        "min_seed_size": "1 TiB"
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 30"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        }
+      ]
+    },
+    {
+      "name": "Specialist",
+      "style": {
+        "color": "#4ADE80",
+        "icon": "fas fa-battery-three-quarters"
+      },
+      "requirements": {
+        "min_uploaded": "4 TiB",
+        "min_ratio": 0.8,
+        "min_age": "6M",
+        "min_seedtime": "3W",
+        "min_seed_size": "1 TiB",
+        "min_uploads": 1
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 50"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Extreme",
+      "style": {
+        "color": "#86EFAC",
+        "icon": "fas fa-battery-full"
+      },
+      "requirements": {
+        "min_uploaded": "6 TiB",
+        "min_ratio": 1,
+        "min_age": "8M",
+        "min_seedtime": "1M",
+        "min_seed_size": "1 TiB"
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 50"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Seeder",
+      "style": {
+        "color": "#67E8F9",
+        "icon": "fas fa-calculator"
+      },
+      "requirements": {
+        "min_uploaded": "8 TiB",
+        "min_ratio": 1,
+        "min_age": "2M",
+        "min_seedtime": "1M",
+        "min_seed_size": "2.5 TiB"
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 75"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Insane User",
+      "style": {
+        "color": "#22D3EE",
+        "icon": "fas fa-laptop",
+        "sparkle": true
+      },
+      "requirements": {
+        "min_uploaded": "12 TiB",
+        "min_ratio": 1,
+        "min_age": "1Y",
+        "min_seedtime": "2M",
+        "min_seed_size": "5 TiB"
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 100"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Legend",
+      "style": {
+        "color": "#0EA5E9",
+        "icon": "fas fa-microchip",
+        "sparkle": true
+      },
+      "requirements": {
+        "description": "Elite uploader rank, awarded by staff for 1,000+ live uploads at a 95%+ survival rate over 6+ months on the team."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 150"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Internal",
+      "style": {
+        "color": "#FBBF24",
+        "icon": "fas fa-helicopter"
+      },
+      "requirements": {
+        "description": "Internal releases."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: Unlimited"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-star text-gold",
+          "label": "Freeleech"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Jr Uploader",
+      "style": {
+        "color": "#FDE68A",
+        "icon": "fas fa-paper-plane"
+      },
+      "requirements": {
+        "description": "Trial uploader working toward full uploader status. Uploader track: 50 total approved uploads. The track is separate from the seeding ladder — entering it also needs 5 approved uploads in the last 30 days, and 90 days with none returns you to the ladder."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 100"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        }
+      ]
+    },
+    {
+      "name": "Veteran",
+      "style": {
+        "color": "#1D4ED8",
+        "icon": "fas fa-cube",
+        "sparkle": true
+      },
+      "requirements": {
+        "min_uploaded": "16 TiB",
+        "min_ratio": 1,
+        "min_age": "1Y",
+        "min_seedtime": "6M",
+        "min_seed_size": "8 TiB"
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 150"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Archivist",
+      "style": {
+        "color": "#1E3A8A",
+        "icon": "fas fa-robot",
+        "sparkle": true
+      },
+      "requirements": {
+        "min_uploaded": "24 TiB",
+        "min_ratio": 1.5,
+        "min_age": "1Y 5M 3W 4D",
+        "min_seedtime": "2M",
+        "min_seed_size": "12 TiB",
+        "min_uploads": 50
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 200"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Uploader",
+      "style": {
+        "color": "#D97706",
+        "icon": "fas fa-rocket"
+      },
+      "requirements": {
+        "description": "Approved content uploader with additional privileges. Uploader track: 150 total approved uploads."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 100"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-shield",
+          "label": "Immune to automated HnR warnings"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        }
+      ]
+    },
+    {
+      "name": "Trustee",
+      "style": {
+        "color": "#FFA585",
+        "icon": "fas fa-shield-halved"
+      },
+      "requirements": {
+        "description": "Trusted members from a respected partner in the community."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 100"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Editor",
+      "style": {
+        "color": "#2DD4BF",
+        "icon": "fas fa-pen-nib"
+      },
+      "requirements": {
+        "description": "Improves metadata, descriptions, tags, and formatting."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 100"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Torrent Mod",
+      "style": {
+        "color": "#14B8A6",
+        "icon": "fas fa-circle-check"
+      },
+      "requirements": {
+        "description": "Reviews torrents for quality and rule compliance."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: 100"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-tv",
+          "label": "IPTV Access"
+        },
+        {
+          "icon": "fas fa-gamepad",
+          "label": "Games Access"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    },
+    {
+      "name": "Bot",
+      "style": {
+        "color": "#9CA3AF",
+        "icon": "fas fa-robot"
+      },
+      "requirements": {
+        "description": "Automated system account used for jobs and notices."
+      },
+      "perks": [
+        {
+          "icon": "fas fa-arrow-down-short-wide text-blue",
+          "label": "DL Slots: Unlimited"
+        },
+        {
+          "icon": "fas fa-upload",
+          "label": "Upload Torrents"
+        },
+        {
+          "icon": "fas fa-paper-plane",
+          "label": "Send invite"
+        },
+        {
+          "icon": "fas fa-star text-gold",
+          "label": "Freeleech"
+        },
+        {
+          "icon": "fas fa-shield",
+          "label": "Immune to automated HnR warnings"
+        },
+        {
+          "icon": "fas fa-forward-fast",
+          "label": "Torrent moderation bypass"
+        },
+        {
+          "icon": "fas fa-comments",
+          "label": "Invite Forum Access"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/api/pathways_test.go
+++ b/internal/api/pathways_test.go
@@ -58,6 +58,12 @@ func TestPathwayNameForFallbacks(t *testing.T) {
 			models.Tracker{Name: "AR", URL: "https://example.invalid"}, "AlphaRatio"},
 		{"def-less, resolves via the URL host when the name doesn't match",
 			models.Tracker{Name: "My Random Import", URL: "https://alpharatio.cc"}, "AlphaRatio"},
+		// HHD's def is named "HHD" while the community dataset calls it
+		// "HomieHelpDesk" — they meet only through the dataset's abbr map. If
+		// that link ever breaks the tracker simply vanishes from Pathways,
+		// with no error and 14 routes silently orphaned.
+		{"def name matches the dataset only via its abbreviation",
+			models.Tracker{Name: "Homie Help Desk", URL: "https://homiehelpdesk.net"}, "HomieHelpDesk"},
 		{"unrelated tracker stays out of the dataset",
 			models.Tracker{Name: "Not A Real Tracker", URL: "https://nowhere.invalid"}, ""},
 	}

--- a/internal/defs/loadall_test.go
+++ b/internal/defs/loadall_test.go
@@ -92,3 +92,55 @@ func TestShippedDefsResolveTheirFetcher(t *testing.T) {
 		}
 	}
 }
+
+// TestHHDDefResolves pins the HHD def's wiring. It is API-only, so a silent
+// regression in any of these leaves the tracker reporting less than it can
+// with nothing to notice — there is no scrape to fall back on.
+func TestHHDDefResolves(t *testing.T) {
+	r, err := Load("../../defs")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	const url = "https://homiehelpdesk.net"
+
+	// Stock /api/user, so the plain UNIT3D fetcher must handle it — an api
+	// block would divert it to the custom fetcher and lose convertCoreBytes.
+	if kind := r.APIKind(url, ""); kind != "unit3d" {
+		t.Errorf("APIKind = %q, want unit3d", kind)
+	}
+
+	fm := r.ResolveAPIFieldMap(url, "unit3d")
+	want := map[string]string{
+		"joined_at":      "join_date",
+		"seedtime_total": "total_seedtime",
+		"uploads_count":  "uploads_approved",
+		"seedbonus":      "bonus_points", // inherited from the type
+	}
+	for from, to := range want {
+		if got := fm[from]; got != to {
+			t.Errorf("field map %q = %q, want %q", from, got, to)
+		}
+	}
+
+	// Scraping off: the class ladder is fully covered by the API, and the def
+	// promises no HTTP beyond /api/user.
+	if sp := r.ResolveScrape(url, "unit3d"); !sp.DisableScraping {
+		t.Errorf("scraping should be disabled: %+v", sp)
+	}
+
+	// Every stat the ladder needs must be declared as an API capability, or
+	// the UI will show requirements it can never evaluate.
+	caps := r.ResolveCapabilities(url, "unit3d")
+	api := map[string]bool{}
+	for _, f := range caps.APIStats {
+		api[f] = true
+	}
+	for _, f := range []string{
+		"username", "group", "join_date", "uploaded", "ratio",
+		"seed_size", "avg_seed_time", "uploads_approved", "last_login",
+	} {
+		if !api[f] {
+			t.Errorf("capability %q missing; have %v", f, caps.APIStats)
+		}
+	}
+}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -148,7 +148,27 @@ func (c *Client) Fetch(t models.Tracker) (map[string]any, *Error) {
 		return nil, ferr
 	}
 	fieldMap := c.Registry.ResolveAPIFieldMap(t.URL, t.Type)
-	return defs.NormalizeAPIFields(fieldMap, data), nil
+	return normalizeStrings(defs.NormalizeAPIFields(fieldMap, data)), nil
+}
+
+// normalizeStrings applies the canonical-string cleanups to every fetcher's
+// output. It runs HERE, after NormalizeAPIFields, because the cleanup is keyed
+// by CANONICAL name and the field map has only just produced those — a def
+// mapping joined_at → join_date still has the raw key inside its fetcher.
+//
+// join_date is what forced this. pathways parses it with a strict
+// time.Parse("2006-01-02"), so an untrimmed "2026-08-21T03:58:59+00:00" fails
+// and the account reads as brand new: every age requirement silently unmet,
+// with no error anywhere. fetchCustom already normalised its own values (it
+// resolves canonical names itself), so for that path this is a no-op — the
+// cleanups are idempotent.
+func normalizeStrings(data map[string]any) map[string]any {
+	for k, v := range data {
+		if str, ok := v.(string); ok {
+			data[k] = normalizeCanonicalString(k, str)
+		}
+	}
+	return data
 }
 
 // ── Unit3D ───────────────────────────────────────────────────────────────────
@@ -954,7 +974,7 @@ func (c *Client) fetchCustom(t models.Tracker) (map[string]any, *Error) {
 		}
 		switch val := v.(type) {
 		case string:
-			out[canonical] = normalizeCustomString(canonical, val)
+			out[canonical] = normalizeCanonicalString(canonical, val)
 		case float64:
 			// Ratio/points fields stay float; other numerics are counts.
 			if canonical == "ratio" || canonical == "bonus_points" || canonical == "fl_tokens" {
@@ -1076,12 +1096,16 @@ func anyTruthy(v any) bool {
 	}
 }
 
-// normalizeCustomString cleans up string values from custom APIs per
-// canonical field, so defs don't each need conversion machinery:
+// normalizeCanonicalString cleans up string values per canonical field, so
+// defs don't each need conversion machinery:
 //   - join_date: ISO datetimes ("2022-01-01T00:00:00+00:00") → date only.
 //   - ratio/real_ratio: "Inf"/"∞" (downloaded = 0) → "Infinity", which the
 //     frontend parses to a real Infinity and renders as ∞ (green).
-func normalizeCustomString(canonical, v string) string {
+//
+// Shared by the custom and UNIT3D fetchers. It was custom-only until a UNIT3D
+// tracker (HHD) started returning a join date from /api/user: stock UNIT3D
+// doesn't report one at all, so the UNIT3D path had never needed it.
+func normalizeCanonicalString(canonical, v string) string {
 	switch canonical {
 	case "join_date":
 		if len(v) > 10 && (v[10] == 'T' || v[10] == ' ') {

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Yata-Dash/Yata-Dash/internal/defs"
 	"github.com/Yata-Dash/Yata-Dash/internal/models"
+	"github.com/Yata-Dash/Yata-Dash/internal/parse"
 )
 
 func gazelleJSONRegistry(t *testing.T, baseURL string) *defs.Registry {
@@ -2162,5 +2163,107 @@ func TestFetchUnit3DExtendedAPIKeyNeverPersisted(t *testing.T) {
 	// The expiry itself is still useful and should be kept.
 	if got := data["api_key_expires_at"]; got != "2027-01-01T00:00:00+00:00" {
 		t.Errorf("api_key_expires_at = %#v, want the extended endpoint's expiry", got)
+	}
+}
+
+// hhdRegistry mirrors defs/trackers/homiehelpdesk.json's wiring onto a test
+// server URL, so the real def's field map can be exercised end-to-end.
+func hhdRegistry(t *testing.T, baseURL string) *defs.Registry {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{"types", "trackers"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	typeJSON := `{"schema_version":1,"key":"unit3d","label":"Unit3D",
+		"api":{"kind":"unit3d"},
+		"api_field_map":{"seedbonus":"bonus_points"}}`
+	trackerJSON := fmt.Sprintf(`{"schema_version":1,"key":"hhd","name":"HHD",
+		"abbr":"HHD","url":%q,"type":"unit3d",
+		"api_field_map":{"joined_at":"join_date","seedtime_total":"total_seedtime","uploads_count":"uploads_approved"}}`, baseURL)
+	if err := os.WriteFile(filepath.Join(dir, "types", "unit3d.json"), []byte(typeJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "trackers", "hhd.json"), []byte(trackerJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := defs.Load(dir)
+	if err != nil {
+		t.Fatalf("defs.Load: %v", err)
+	}
+	return reg
+}
+
+// TestFetchUnit3DHHDResponseShape covers HHD, the first UNIT3D tracker to
+// report a join date from /api/user.
+//
+// The join_date assertion is the one that matters: pathways parses it with a
+// strict time.Parse("2006-01-02"), so an untrimmed "2026-08-21T03:58:59+00:00"
+// would make a year-old account read as brand new and quietly fail every age
+// requirement in the ladder.
+func TestFetchUnit3DHHDResponseShape(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/user" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sekrit" {
+			t.Errorf("Authorization = %q, want Bearer (HHD rejects ?api_token=)", got)
+		}
+		fmt.Fprint(w, `{
+			"username":"testuser","group":"User",
+			"uploaded":"51.61 GiB","downloaded":"1 GiB","ratio":51.61,"buffer":"128.03 GiB",
+			"seedbonus":"11340.00","seeding":455,"leeching":0,"hit_and_runs":0,
+			"seed_size":"5.06 TiB","avg_seed_time":"1D  4h  30m  20s",
+			"fl_tokens":0,"invites":0,
+			"real_uploaded":1730497944,"real_downloaded":0,
+			"joined_at":"2026-08-21T03:58:59+00:00","last_login":"2026-08-30T01:12:50+00:00",
+			"seedtime_total":46692286,"uploads_count":0,"downloads_count":0
+		}`)
+	}))
+	defer ts.Close()
+
+	c := NewClient(hhdRegistry(t, ts.URL), "")
+	data, ferr := c.Fetch(models.Tracker{URL: ts.URL, Type: "unit3d", APIKey: "sekrit"})
+	if ferr != nil {
+		t.Fatalf("Fetch: %v", ferr)
+	}
+	want := map[string]any{
+		"username": "testuser", "group": "User",
+		"uploaded": "51.61 GiB", "downloaded": "1 GiB", "ratio": 51.61,
+		"buffer": "128.03 GiB", "bonus_points": "11340.00",
+		"seeding": 455.0, "leeching": 0.0, "hit_and_runs": 0.0,
+		"seed_size": "5.06 TiB", "avg_seed_time": "1D  4h  30m  20s",
+		"fl_tokens": 0.0, "invites": 0.0,
+		"join_date":        "2026-08-21", // trimmed from the ISO datetime
+		"total_seedtime":   46692286.0,
+		"uploads_approved": 0.0,
+		// NOT trimmed, unlike join_date above: nothing parses it yet, and a
+		// future login-recency rule may want the time of day.
+		"last_login": "2026-08-30T01:12:50+00:00",
+	}
+	for key, expected := range want {
+		if got := data[key]; got != expected {
+			t.Errorf("%s = %#v, want %#v", key, got, expected)
+		}
+	}
+	// real_uploaded arrives as a byte NUMBER and must be converted, unlike the
+	// pre-formatted core values beside it.
+	if got, ok := data["real_uploaded"].(string); !ok || !strings.HasSuffix(got, "GiB") {
+		t.Errorf("real_uploaded = %#v, want a converted size string", data["real_uploaded"])
+	}
+	if _, ok := data["seedbonus"]; ok {
+		t.Errorf("seedbonus alias should be normalized away: %+v", data)
+	}
+}
+
+// TestSeedTimeParsesHHDFormat confirms the formatted avg_seed_time HHD returns
+// resolves to exactly the avg_seed_time_raw it reports alongside it — which is
+// why the _raw twin is deliberately left unmapped in the def.
+func TestSeedTimeParsesHHDFormat(t *testing.T) {
+	got := parse.SeedTimeToSeconds("1D  4h  30m  20s")
+	if got == nil || *got != 102620 {
+		t.Errorf("SeedTimeToSeconds = %v, want 102620 (avg_seed_time_raw)", got)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HomieHelpdesk as an API-only tracker, including account statistics, progression groups, requirements and perks.
  - Added support for join dates and last-login times across supported trackers.
  - Updated pathway data to the August 2026 community dataset, now containing 591 routes.
  - Consolidated group and class alerts with options for changes, promotions and demotions.

- **Bug Fixes**
  - Fixed LST statistics after its API changes, including API key expiry handling.
  - Corrected a truncated pathway requirement.
  - Improved timestamp and value normalisation across tracker integrations.

- **Documentation**
  - Expanded API field documentation for progression-related statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->